### PR TITLE
Fix intra-package references

### DIFF
--- a/procbridge/__init__.py
+++ b/procbridge/__init__.py
@@ -1,9 +1,9 @@
 import threading
 import socket
-import protocol as p
+from . import protocol as p
 from typing import Any, Callable
-from errors import ProtocolError, ServerError
-from const import StatusCode, Versions
+from .errors import ProtocolError, ServerError
+from .const import StatusCode, Versions
 
 __all__ = ["Server", "Client", "Versions", "ProtocolError", "ServerError"]
 

--- a/procbridge/protocol.py
+++ b/procbridge/protocol.py
@@ -2,8 +2,8 @@ import socket
 import json
 from typing import Any
 
-from const import StatusCode, Keys, Versions
-from errors import ProtocolError, ErrorMessages
+from .const import StatusCode, Keys, Versions
+from .errors import ProtocolError, ErrorMessages
 
 
 def read_bytes(s: socket.socket, count: int) -> bytes:


### PR DESCRIPTION
The intra-package references don't work when code is executed outside the root folder of the project.
To fix this, intra-package references should use relative imports in the form of `from module import name`.
See [the Python documentation](https://docs.python.org/3/tutorial/modules.html#intra-package-references).