### PR TITLE
Avoid referencing socket.AF_UNIX on non-unix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please note that this repo is the **Python implementation** of ProcBridge protoc
 # Installation
 
 ```
-pip install procbridge==1.2.0
+pip install procbridge==1.2.1
 ```
 
 # Example

--- a/procbridge/__init__.py
+++ b/procbridge/__init__.py
@@ -28,7 +28,7 @@ class Client:
         return cls(host, port)
 
     def request(self, method: str, payload: Any = None) -> Any:
-        if self.family == socket.AF_UNIX:
+        if self.path is not None:
             s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             s.connect(self.path)
         else:
@@ -74,7 +74,7 @@ class Server:
             if self.started:
                 return
 
-            if self.family == socket.AF_UNIX:
+            if self.path is not None:
                 self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 self.socket.bind(self.path)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="procbridge",
-    version="1.2.0",
+    version="1.2.1",
     author="Gong Zhang",
     author_email="gong@me.com",
     description="A super-lightweight IPC (Inter-Process Communication) protocol over TCP socket.",


### PR DESCRIPTION
Most of my computers are *nix based, but some of them are not.
I noticed that `socket.AF_UNIX` is not defined on those computers. 
Trying to reference it, even as a part of a comparison, raises the following error:

`AttributeError: module 'socket' has no attribute 'AF_UNIX'`

Relying on the `self.path` property is a safe alternative.