### PR TITLE
json.loads doesn't support argument encoding

### DIFF
--- a/procbridge/protocol.py
+++ b/procbridge/protocol.py
@@ -58,7 +58,7 @@ def read_socket(s: socket.socket) -> (int, dict):
         raise ProtocolError(ErrorMessages.INCOMPLETE_DATA,
                             'expect ' + str(json_len) + ' bytes but found ' + str(len(text_bytes)))
     try:
-        obj = json.loads(str(text_bytes, encoding='utf-8'), encoding='utf-8')
+        obj = json.loads(str(text_bytes, encoding='utf-8'))
     except Exception as err:
         raise ProtocolError(ErrorMessages.INVALID_BODY, "{}".format(err))
 


### PR DESCRIPTION
Using server and client from example.
On raspberryPi with python3.9 I was getting exception
`__init__() got an unexpected keyword argument 'encoding'`
from line 61 in file protocol.py